### PR TITLE
Tweaks for Mac

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -31,5 +31,9 @@
     {
         "caption": "Terminal: Open in project folder",
         "command": "open_terminal_project_folder"
+    },
+    {
+        "caption": "Terminal: Switch to application",
+        "command": "switch_to_terminal"
     }
 ]

--- a/Terminal.py
+++ b/Terminal.py
@@ -213,3 +213,13 @@ class OpenTerminalProjectFolderCommand(sublime_plugin.WindowCommand, TerminalCom
 
         command = OpenTerminalCommand(self.window)
         command.run(folders, parameters=parameters)
+
+
+class SwitchToTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
+    def is_visible(self):
+        # only have an applescript to do this
+        return sys.platform == 'darwin'
+
+    def run(self, paths=[], parameters=None):
+        package_dir = os.path.join(sublime.packages_path(), INSTALLED_DIR)
+        subprocess.Popen(os.path.join(package_dir, 'TerminalSwitch.sh'))

--- a/Terminal.sh
+++ b/Terminal.sh
@@ -8,12 +8,15 @@ try
 		if (count(processes whose name is "Terminal")) is 0 then
 			tell application "Terminal"
 				activate
+				delay 0.1
 				set miniaturized of window 1 to false
+				delay 0.1
 				do script "$CD_CMD" in window 1
 			end tell
 		else
 			tell application "Terminal"
 				activate
+				delay 0.2
 				do script "$CD_CMD"
 			end tell
 		end if

--- a/TerminalReuse.sh
+++ b/TerminalReuse.sh
@@ -15,6 +15,8 @@ try
 			end tell
 		end if
 
+		delay 0.3
+
 		tell application "Terminal"
 			set miniaturized of window 1 to false
 			do script "$CD_CMD" in window 1

--- a/TerminalSwitch.sh
+++ b/TerminalSwitch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+CD_CMD="cd "\\\"$(pwd)\\\"""
+
+osascript<<END
+try
+	tell application "System Events"
+		tell application "Terminal"
+			activate
+		end tell
+
+		if not (exists (window 1 of process "Terminal")) then
+			tell application "Terminal"
+				do script "" -- opens a new window
+			end tell
+		end if
+
+		delay 0.3
+
+		tell application "Terminal"
+			set miniaturized of window 1 to false
+		end tell
+	end tell
+end try
+END


### PR DESCRIPTION
- some minor delays prevent misfire on a cold launch
- add "switch to terminal" command for Mac, that brings the terminal app forward without running anything