### PR TITLE
feat: add linux switch to terminal

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -33,7 +33,7 @@
         "command": "open_terminal_project_folder"
     },
     {
-        "caption": "Terminal: Switch to application",
+        "caption": "Terminal: Switch to terminal",
         "command": "switch_to_terminal"
     }
 ]

--- a/Terminal.py
+++ b/Terminal.py
@@ -91,6 +91,20 @@ def _has_linux_xdotool():
     return sys.platform == 'linux' and bool(shutil.which('xdotool'))
 
 
+def _find_wid_by_pid(pid):
+    """Find a terminal window ID by process PID. Returns None if not found."""
+    try:
+        result = subprocess.check_output(
+            ['xdotool', 'search', '--pid', str(pid)],
+            timeout=2, stderr=subprocess.DEVNULL
+        ).decode().strip()
+        if result:
+            return result.splitlines()[-1]
+    except (Exception):
+        pass
+    return None
+
+
 class TerminalSelector():
     default = None
 
@@ -184,18 +198,20 @@ class TerminalCommand():
                     pass
 
             # Run our process
-            subprocess.Popen(args, cwd=location, env=env)
+            proc = subprocess.Popen(args, cwd=location, env=env)
 
             # On Linux, capture the new terminal's window ID after it
             # appears and takes focus. Used by SwitchToTerminalCommand.
             if _has_linux_xdotool():
                 def _capture_wid():
                     try:
-                        wid = subprocess.check_output(
-                            ['xdotool', 'getactivewindow'],
-                            timeout=2, stderr=subprocess.DEVNULL
-                        ).decode().strip()
-                        if wid not in _terminal_wid_stack:
+                        wid = _find_wid_by_pid(proc.pid)
+                        if not wid:
+                            wid = subprocess.check_output(
+                                ['xdotool', 'getactivewindow'],
+                                timeout=2, stderr=subprocess.DEVNULL
+                            ).decode().strip()
+                        if wid and wid not in _terminal_wid_stack:
                             _terminal_wid_stack.append(wid)
                     except (Exception):
                         pass

--- a/Terminal.py
+++ b/Terminal.py
@@ -261,7 +261,7 @@ class SwitchToTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
     def run(self, paths=[], parameters=None):
         if sys.platform == 'darwin':
             package_dir = os.path.join(sublime.packages_path(), INSTALLED_DIR)
-            subprocess.Popen(os.path.join(package_dir, 'TerminalSwitch.sh'))
+            subprocess.run(os.path.join(package_dir, 'TerminalSwitch.sh'))
         elif sys.platform == 'linux':
             try:
                 activated = False
@@ -274,7 +274,9 @@ class SwitchToTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
                             ['xdotool', 'getwindowname', wid],
                             timeout=2, stderr=subprocess.DEVNULL)
                         # Window exists -- activate it
-                        subprocess.Popen(['xdotool', 'windowactivate', wid])
+                        subprocess.run(
+                            ['xdotool', 'windowactivate', wid],
+                            timeout=2, stderr=subprocess.DEVNULL)
                         activated = True
                         break
                     except subprocess.CalledProcessError:
@@ -286,10 +288,10 @@ class SwitchToTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
                     if not terminal_class:
                         terminal = get_setting('terminal', '') or linux_terminal()
                         terminal_class = os.path.basename(terminal)
-                    subprocess.Popen([
+                    subprocess.run([
                         'xdotool', 'search', '--class',
                         terminal_class, 'windowactivate',
-                    ])
+                    ], timeout=2, stderr=subprocess.DEVNULL)
             except (Exception) as exception:
                 print(str(exception))
                 sublime.error_message(

--- a/Terminal.py
+++ b/Terminal.py
@@ -1,6 +1,7 @@
 import sublime
 import sublime_plugin
 import os
+import shutil
 import sys
 import subprocess
 
@@ -17,6 +18,11 @@ class NotFoundError(Exception):
 
 
 INSTALLED_DIR = __name__.split('.')[0]
+
+# Stack of terminal window IDs opened from Sublime (Linux only).
+# SwitchToTerminalCommand activates the most recent live window,
+# falling back to older ones when a terminal is closed.
+_terminal_wid_stack = []
 
 
 def get_setting(key, default=None):
@@ -79,6 +85,10 @@ def linux_terminal():
 
     # nothing specific found, return a default
     return 'xterm'
+
+
+def _has_linux_xdotool():
+    return sys.platform == 'linux' and bool(shutil.which('xdotool'))
 
 
 class TerminalSelector():
@@ -161,8 +171,35 @@ class TerminalCommand():
                 else:
                     env[k] = env_setting[k]
 
+            # On Linux, inject Sublime's window ID so the spawned terminal
+            # can switch focus back (requires xdotool)
+            if _has_linux_xdotool():
+                try:
+                    sublime_wid = subprocess.check_output(
+                        ['xdotool', 'getactivewindow'],
+                        timeout=2, stderr=subprocess.DEVNULL
+                    ).decode().strip()
+                    env['SUBLIME_TERMINAL_OPENER_WID'] = sublime_wid
+                except (Exception):
+                    pass
+
             # Run our process
             subprocess.Popen(args, cwd=location, env=env)
+
+            # On Linux, capture the new terminal's window ID after it
+            # appears and takes focus. Used by SwitchToTerminalCommand.
+            if _has_linux_xdotool():
+                def _capture_wid():
+                    try:
+                        wid = subprocess.check_output(
+                            ['xdotool', 'getactivewindow'],
+                            timeout=2, stderr=subprocess.DEVNULL
+                        ).decode().strip()
+                        if wid not in _terminal_wid_stack:
+                            _terminal_wid_stack.append(wid)
+                    except (Exception):
+                        pass
+                sublime.set_timeout(_capture_wid, 1500)
 
         except (OSError) as exception:
             print(str(exception))
@@ -217,9 +254,46 @@ class OpenTerminalProjectFolderCommand(sublime_plugin.WindowCommand, TerminalCom
 
 class SwitchToTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
     def is_visible(self):
-        # only have an applescript to do this
-        return sys.platform == 'darwin'
+        if sys.platform == 'darwin':
+            return True
+        return _has_linux_xdotool()
 
     def run(self, paths=[], parameters=None):
-        package_dir = os.path.join(sublime.packages_path(), INSTALLED_DIR)
-        subprocess.Popen(os.path.join(package_dir, 'TerminalSwitch.sh'))
+        if sys.platform == 'darwin':
+            package_dir = os.path.join(sublime.packages_path(), INSTALLED_DIR)
+            subprocess.Popen(os.path.join(package_dir, 'TerminalSwitch.sh'))
+        elif sys.platform == 'linux':
+            try:
+                activated = False
+
+                # Walk the stack from most recent, prune dead windows
+                while _terminal_wid_stack:
+                    wid = _terminal_wid_stack[-1]
+                    try:
+                        subprocess.check_output(
+                            ['xdotool', 'getwindowname', wid],
+                            timeout=2, stderr=subprocess.DEVNULL)
+                        # Window exists -- activate it
+                        subprocess.Popen(['xdotool', 'windowactivate', wid])
+                        activated = True
+                        break
+                    except subprocess.CalledProcessError:
+                        _terminal_wid_stack.pop()
+
+                if not activated:
+                    # Fallback: activate by WM_CLASS
+                    terminal_class = get_setting('terminal_class', '')
+                    if not terminal_class:
+                        terminal = get_setting('terminal', '') or linux_terminal()
+                        terminal_class = os.path.basename(terminal)
+                    subprocess.Popen([
+                        'xdotool', 'search', '--class',
+                        terminal_class, 'windowactivate',
+                    ])
+            except (Exception) as exception:
+                print(str(exception))
+                sublime.error_message(
+                    'Terminal: xdotool not found. Install it with:\n'
+                    '- Debian/Ubuntu/Mint: sudo apt install xdotool\n'
+                    '- Arch: sudo pacman -S xdotool\n'
+                    '- Fedora: sudo dnf install xdotool')

--- a/Terminal.py
+++ b/Terminal.py
@@ -20,10 +20,10 @@ class NotFoundError(Exception):
 
 INSTALLED_DIR = __name__.split('.')[0]
 
-# Stack of terminal window IDs opened from Sublime (Linux only).
-# SwitchToTerminalCommand activates the most recent live window,
+# Stacks of terminal window IDs opened from each Sublime window (Linux only).
+# SwitchToTerminalCommand activates the most recent live window for its opener,
 # falling back to older ones when a terminal is closed.
-_terminal_wid_stack = []
+_terminal_wid_stacks = {}
 
 
 def get_setting(key, default=None):
@@ -125,11 +125,7 @@ def _find_wid_by_pid(pid):
     backend = _linux_window_backend()
     try:
         if backend == 'hyprland':
-            out = subprocess.check_output(
-                ['hyprctl', 'clients', '-j'],
-                timeout=2, stderr=subprocess.DEVNULL
-            ).decode().strip()
-            for client in json.loads(out):
+            for client in _hyprland_clients():
                 if client.get('pid') == pid:
                     return client.get('address')
         elif backend == 'xdotool':
@@ -148,11 +144,7 @@ def _is_window_alive(wid):
     backend = _linux_window_backend()
     try:
         if backend == 'hyprland':
-            out = subprocess.check_output(
-                ['hyprctl', 'clients', '-j'],
-                timeout=2, stderr=subprocess.DEVNULL
-            ).decode().strip()
-            return any(c.get('address') == wid for c in json.loads(out))
+            return any(c.get('address') == wid for c in _hyprland_clients())
         elif backend == 'xdotool':
             subprocess.check_output(
                 ['xdotool', 'getwindowname', wid],
@@ -194,20 +186,74 @@ def _activate_by_class(class_name):
         pass
 
 
-def _tag_sublime_window():
-    """Tag Sublime's window for Hyprland tag-based focus switching."""
-    if _linux_window_backend() == 'hyprland':
+def _hyprland_clients():
+    try:
+        out = subprocess.check_output(
+            ['hyprctl', 'clients', '-j'],
+            timeout=2, stderr=subprocess.DEVNULL
+        ).decode().strip()
+        return json.loads(out)
+    except (Exception):
+        return []
+
+
+def _hyprland_tag_window(tag, selector, add=True):
+    args = ['hyprctl', 'dispatch', 'tagwindow']
+    if not add:
+        # Without this, hyprctl parses "-tag" as a hyprctl option.
+        args.append('--')
+    args.extend([('+' if add else '-') + tag, selector])
+    subprocess.run(
+        args, timeout=2, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL)
+
+
+def _remove_hyprland_tag(tag):
+    for client in _hyprland_clients():
+        if tag in client.get('tags', []):
+            _hyprland_tag_window(
+                tag, 'address:' + client.get('address'), add=False)
+
+
+def _hyprland_window_ids():
+    return set(
+        c.get('address') for c in _hyprland_clients() if c.get('address'))
+
+
+def _find_new_hyprland_wid(before_wids):
+    clients = [
+        c for c in _hyprland_clients()
+        if c.get('address') and c.get('address') not in before_wids
+    ]
+    if not clients:
+        return None
+
+    active_wid = _get_active_wid()
+    if active_wid in [c.get('address') for c in clients]:
+        return active_wid
+
+    clients.sort(key=lambda c: c.get('focusHistoryID', 999999))
+    return clients[0].get('address')
+
+
+def _sublime_opener_tag(window_id):
+    return 'sublime-opener-' + str(window_id)
+
+
+def _tag_sublime_window(window_id, wid):
+    """Tag a specific Sublime window for Hyprland focus switching."""
+    tag = _sublime_opener_tag(window_id)
+    if _linux_window_backend() == 'hyprland' and wid:
         try:
-            # Plugins run in plugin_host (child process).
-            # The window belongs to sublime_text (parent process).
-            sublime_pid = os.getppid()
-            subprocess.run(
-                ['hyprctl', 'dispatch', 'tagwindow',
-                 '+sublime-opener pid:' + str(sublime_pid)],
-                timeout=2, stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL)
+            # Keep the documented generic tag best-effort, but also add a
+            # window-specific tag for shells that receive it in their env.
+            _remove_hyprland_tag('sublime-opener')
+            _remove_hyprland_tag(tag)
+            _hyprland_tag_window('sublime-opener', 'address:' + wid)
+            _hyprland_tag_window(tag, 'address:' + wid)
         except (Exception):
             pass
+    return tag
 
 
 class TerminalSelector():
@@ -276,6 +322,7 @@ class TerminalCommand():
 
     def open_terminal(self, location, terminal, parameters):
         try:
+            window_id = self.window.id()
             for k, v in enumerate(parameters):
                 parameters[k] = v.replace('%CWD%', location)
             args = [TerminalSelector.get(terminal)]
@@ -296,11 +343,16 @@ class TerminalCommand():
             # single-instance terminals (e.g. Ghostty gtk-single-instance).
             # X11: inject Sublime's window ID as env var for xdotool.
             if _has_linux_window_tool():
-                _tag_sublime_window()
-                if _linux_window_backend() == 'xdotool':
-                    sublime_wid = _find_wid_by_pid(os.getppid()) or _get_active_wid()
-                    if sublime_wid:
-                        env['SUBLIME_TERMINAL_OPENER_WID'] = sublime_wid
+                sublime_wid = _get_active_wid()
+                if _linux_window_backend() == 'hyprland':
+                    env['SUBLIME_TERMINAL_OPENER_TAG'] = _tag_sublime_window(
+                        window_id, sublime_wid)
+                elif sublime_wid:
+                    env['SUBLIME_TERMINAL_OPENER_WID'] = sublime_wid
+
+            before_wids = set()
+            if _linux_window_backend() == 'hyprland':
+                before_wids = _hyprland_window_ids()
 
             # Run our process
             proc = subprocess.Popen(args, cwd=location, env=env)
@@ -311,10 +363,13 @@ class TerminalCommand():
                 def _capture_wid():
                     try:
                         wid = _find_wid_by_pid(proc.pid)
+                        if not wid and _linux_window_backend() == 'hyprland':
+                            wid = _find_new_hyprland_wid(before_wids)
                         if not wid:
                             wid = _get_active_wid()
-                        if wid and wid not in _terminal_wid_stack:
-                            _terminal_wid_stack.append(wid)
+                        stack = _terminal_wid_stacks.setdefault(window_id, [])
+                        if wid and wid not in stack:
+                            stack.append(wid)
                     except (Exception):
                         pass
                 sublime.set_timeout(_capture_wid, 1500)
@@ -395,14 +450,15 @@ class SwitchToTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
             activated = False
 
             # Walk the stack from most recent, prune dead windows
-            while _terminal_wid_stack:
-                wid = _terminal_wid_stack[-1]
+            stack = _terminal_wid_stacks.setdefault(self.window.id(), [])
+            while stack:
+                wid = stack[-1]
                 if _is_window_alive(wid):
                     _activate_window(wid)
                     activated = True
                     break
                 else:
-                    _terminal_wid_stack.pop()
+                    stack.pop()
 
             if not activated:
                 # Fallback: activate by window class

--- a/Terminal.py
+++ b/Terminal.py
@@ -1,5 +1,6 @@
 import sublime
 import sublime_plugin
+import json
 import os
 import shutil
 import sys
@@ -87,22 +88,126 @@ def linux_terminal():
     return 'xterm'
 
 
-def _has_linux_xdotool():
-    return sys.platform == 'linux' and bool(shutil.which('xdotool'))
+def _linux_window_backend():
+    if sys.platform != 'linux':
+        return None
+    if os.environ.get('HYPRLAND_INSTANCE_SIGNATURE') and shutil.which('hyprctl'):
+        return 'hyprland'
+    if shutil.which('xdotool'):
+        return 'xdotool'
+    return None
 
 
-def _find_wid_by_pid(pid):
-    """Find a terminal window ID by process PID. Returns None if not found."""
+def _has_linux_window_tool():
+    return _linux_window_backend() is not None
+
+
+def _get_active_wid():
+    backend = _linux_window_backend()
     try:
-        result = subprocess.check_output(
-            ['xdotool', 'search', '--pid', str(pid)],
-            timeout=2, stderr=subprocess.DEVNULL
-        ).decode().strip()
-        if result:
-            return result.splitlines()[-1]
+        if backend == 'hyprland':
+            out = subprocess.check_output(
+                ['hyprctl', 'activewindow', '-j'],
+                timeout=2, stderr=subprocess.DEVNULL
+            ).decode().strip()
+            return json.loads(out).get('address')
+        elif backend == 'xdotool':
+            return subprocess.check_output(
+                ['xdotool', 'getactivewindow'],
+                timeout=2, stderr=subprocess.DEVNULL
+            ).decode().strip()
     except (Exception):
         pass
     return None
+
+
+def _find_wid_by_pid(pid):
+    backend = _linux_window_backend()
+    try:
+        if backend == 'hyprland':
+            out = subprocess.check_output(
+                ['hyprctl', 'clients', '-j'],
+                timeout=2, stderr=subprocess.DEVNULL
+            ).decode().strip()
+            for client in json.loads(out):
+                if client.get('pid') == pid:
+                    return client.get('address')
+        elif backend == 'xdotool':
+            result = subprocess.check_output(
+                ['xdotool', 'search', '--pid', str(pid)],
+                timeout=2, stderr=subprocess.DEVNULL
+            ).decode().strip()
+            if result:
+                return result.splitlines()[-1]
+    except (Exception):
+        pass
+    return None
+
+
+def _is_window_alive(wid):
+    backend = _linux_window_backend()
+    try:
+        if backend == 'hyprland':
+            out = subprocess.check_output(
+                ['hyprctl', 'clients', '-j'],
+                timeout=2, stderr=subprocess.DEVNULL
+            ).decode().strip()
+            return any(c.get('address') == wid for c in json.loads(out))
+        elif backend == 'xdotool':
+            subprocess.check_output(
+                ['xdotool', 'getwindowname', wid],
+                timeout=2, stderr=subprocess.DEVNULL)
+            return True
+    except (Exception):
+        pass
+    return False
+
+
+def _activate_window(wid):
+    backend = _linux_window_backend()
+    try:
+        if backend == 'hyprland':
+            subprocess.run(
+                ['hyprctl', 'dispatch', 'focuswindow', 'address:' + wid],
+                timeout=2, stderr=subprocess.DEVNULL)
+        elif backend == 'xdotool':
+            subprocess.run(
+                ['xdotool', 'windowactivate', wid],
+                timeout=2, stderr=subprocess.DEVNULL)
+    except (Exception):
+        pass
+
+
+def _activate_by_class(class_name):
+    backend = _linux_window_backend()
+    try:
+        if backend == 'hyprland':
+            subprocess.run(
+                ['hyprctl', 'dispatch', 'focuswindow', 'class:' + class_name],
+                timeout=2, stderr=subprocess.DEVNULL)
+        elif backend == 'xdotool':
+            subprocess.run([
+                'xdotool', 'search', '--class',
+                class_name, 'windowactivate',
+            ], timeout=2, stderr=subprocess.DEVNULL)
+    except (Exception):
+        pass
+
+
+def _tag_sublime_window():
+    """Tag Sublime's window for Hyprland tag-based focus switching."""
+    if _linux_window_backend() == 'hyprland':
+        try:
+            # Plugins run in plugin_host (child process).
+            # The window belongs to sublime_text (parent process).
+            sublime_pid = os.getppid()
+            subprocess.run(
+                ['hyprctl', 'dispatch', 'tagwindow',
+                 '+sublime-opener pid:' + str(sublime_pid)],
+                timeout=2, stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL)
+        except (Exception):
+            pass
 
 
 class TerminalSelector():
@@ -185,32 +290,29 @@ class TerminalCommand():
                 else:
                     env[k] = env_setting[k]
 
-            # On Linux, inject Sublime's window ID so the spawned terminal
-            # can switch focus back (requires xdotool)
-            if _has_linux_xdotool():
-                try:
-                    sublime_wid = subprocess.check_output(
-                        ['xdotool', 'getactivewindow'],
-                        timeout=2, stderr=subprocess.DEVNULL
-                    ).decode().strip()
-                    env['SUBLIME_TERMINAL_OPENER_WID'] = sublime_wid
-                except (Exception):
-                    pass
+            # On Linux, set up bidirectional focus switching.
+            # Hyprland: tag Sublime's window so terminals can focus
+            # back via hyprctl's tag selector. Env vars don't survive
+            # single-instance terminals (e.g. Ghostty gtk-single-instance).
+            # X11: inject Sublime's window ID as env var for xdotool.
+            if _has_linux_window_tool():
+                _tag_sublime_window()
+                if _linux_window_backend() == 'xdotool':
+                    sublime_wid = _find_wid_by_pid(os.getppid()) or _get_active_wid()
+                    if sublime_wid:
+                        env['SUBLIME_TERMINAL_OPENER_WID'] = sublime_wid
 
             # Run our process
             proc = subprocess.Popen(args, cwd=location, env=env)
 
             # On Linux, capture the new terminal's window ID after it
             # appears and takes focus. Used by SwitchToTerminalCommand.
-            if _has_linux_xdotool():
+            if _has_linux_window_tool():
                 def _capture_wid():
                     try:
                         wid = _find_wid_by_pid(proc.pid)
                         if not wid:
-                            wid = subprocess.check_output(
-                                ['xdotool', 'getactivewindow'],
-                                timeout=2, stderr=subprocess.DEVNULL
-                            ).decode().strip()
+                            wid = _get_active_wid()
                         if wid and wid not in _terminal_wid_stack:
                             _terminal_wid_stack.append(wid)
                     except (Exception):
@@ -272,46 +374,40 @@ class SwitchToTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
     def is_visible(self):
         if sys.platform == 'darwin':
             return True
-        return _has_linux_xdotool()
+        return _has_linux_window_tool()
 
     def run(self, paths=[], parameters=None):
         if sys.platform == 'darwin':
             package_dir = os.path.join(sublime.packages_path(), INSTALLED_DIR)
             subprocess.run(os.path.join(package_dir, 'TerminalSwitch.sh'))
         elif sys.platform == 'linux':
-            try:
-                activated = False
-
-                # Walk the stack from most recent, prune dead windows
-                while _terminal_wid_stack:
-                    wid = _terminal_wid_stack[-1]
-                    try:
-                        subprocess.check_output(
-                            ['xdotool', 'getwindowname', wid],
-                            timeout=2, stderr=subprocess.DEVNULL)
-                        # Window exists -- activate it
-                        subprocess.run(
-                            ['xdotool', 'windowactivate', wid],
-                            timeout=2, stderr=subprocess.DEVNULL)
-                        activated = True
-                        break
-                    except subprocess.CalledProcessError:
-                        _terminal_wid_stack.pop()
-
-                if not activated:
-                    # Fallback: activate by WM_CLASS
-                    terminal_class = get_setting('terminal_class', '')
-                    if not terminal_class:
-                        terminal = get_setting('terminal', '') or linux_terminal()
-                        terminal_class = os.path.basename(terminal)
-                    subprocess.run([
-                        'xdotool', 'search', '--class',
-                        terminal_class, 'windowactivate',
-                    ], timeout=2, stderr=subprocess.DEVNULL)
-            except (Exception) as exception:
-                print(str(exception))
+            if not _has_linux_window_tool():
                 sublime.error_message(
-                    'Terminal: xdotool not found. Install it with:\n'
+                    'Terminal: No supported window tool found.\n'
+                    'For X11, install xdotool:\n'
                     '- Debian/Ubuntu/Mint: sudo apt install xdotool\n'
                     '- Arch: sudo pacman -S xdotool\n'
-                    '- Fedora: sudo dnf install xdotool')
+                    '- Fedora: sudo dnf install xdotool\n'
+                    'For Hyprland, hyprctl is detected automatically.\n'
+                    'Other Wayland compositors are not currently supported.')
+                return
+
+            activated = False
+
+            # Walk the stack from most recent, prune dead windows
+            while _terminal_wid_stack:
+                wid = _terminal_wid_stack[-1]
+                if _is_window_alive(wid):
+                    _activate_window(wid)
+                    activated = True
+                    break
+                else:
+                    _terminal_wid_stack.pop()
+
+            if not activated:
+                # Fallback: activate by window class
+                terminal_class = get_setting('terminal_class', '')
+                if not terminal_class:
+                    terminal = get_setting('terminal', '') or linux_terminal()
+                    terminal_class = os.path.basename(terminal)
+                _activate_by_class(terminal_class)

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -16,5 +16,12 @@
 
 	// For the Mac Terminal.app only, allow reuse of the front-most window,
 	// instead of spawning a new window
-	"reuse_window": false
+	"reuse_window": false,
+
+	// The WM_CLASS of the terminal, used by "Switch to Terminal" on Linux.
+	// If blank, derived from the "terminal" setting. Override this if your
+	// terminal's WM_CLASS differs from its executable name (e.g. gnome-terminal
+	// uses "gnome-terminal-server").
+	// Find yours with: xdotool getactivewindow getwindowclassname
+	"terminal_class": ""
 }

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -1,7 +1,7 @@
 {
 	// The command to execute for the terminal, leave blank for the OS default
 	// See https://github.com/wbond/sublime_terminal#examples for examples
-	"terminal": "",
+	"terminal": null,
 
 	// A list of default parameters to pass to the terminal, this can be
 	// overridden by passing the "parameters" key with a list value to the args
@@ -19,9 +19,9 @@
 	"reuse_window": false,
 
 	// The WM_CLASS of the terminal, used by "Switch to Terminal" on Linux.
-	// If blank, derived from the "terminal" setting. Override this if your
+	// If not set, derived from the "terminal" setting. Override this if your
 	// terminal's WM_CLASS differs from its executable name (e.g. gnome-terminal
 	// uses "gnome-terminal-server").
 	// Find yours with: xdotool getactivewindow getwindowclassname
-	"terminal_class": ""
+	"terminal_class": null
 }

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,17 @@ Download [Package Control](https://packagecontrol.io/) and use the *Package Cont
   Opens a terminal in the folder containing the currently opened file.  
 - **Open Terminal at Project Folder**
   Opens a terminal in the project folder containing the currently opened file.  
+- **Switch to Terminal**
+  Switches focus to the most recently opened terminal window.
+  On macOS this uses AppleScript. On Linux this requires
+  [xdotool](https://github.com/jordansissel/xdotool), pre-installed or
+  available via your distribution's package manager:
+
+  - Debian/Ubuntu/Mint: `sudo apt install xdotool`
+  - Arch: `sudo pacman -S xdotool`
+  - Fedora: `sudo dnf install xdotool`
+
+
 
 Terminals can be opened via the command palette, the editor context menu and the sidebar context menus. Additionally, you can set up key bindings.
 
@@ -42,6 +53,9 @@ The settings can be viewed and edited by accessing the *Preferences > Package Se
      - The environment variables changeset. Default environment variables used when invoking the terminal are inherited from Sublime Text.
      - The changeset may be used to overwrite/unset environment variables. Use `null` to indicate that the environment variable should be unset.
      - Default: `{}`
+ - **terminal_class**
+     - The WM_CLASS of the terminal, used by "Switch to Terminal" on Linux. If blank, derived from the `terminal` setting. Override this if your terminal's WM_CLASS differs from its executable name. Find yours with: `xdotool getactivewindow getwindowclassname`
+     - Default: `""`
 
 ## Custom Parameters
 
@@ -70,6 +84,37 @@ A parameter may also contain the *%CWD%* placeholder, which will be substituted 
  }
 }
 ```
+
+### Switching between Sublime Text and a terminal (Linux)
+
+1. **Switching from Sublime to terminal**
+
+    The "Switch to Terminal" command activates the most recently opened
+    terminal window that was opened from within Sublime Text (externally
+    launched terminals are not tracked). All terminals opened from Sublime
+    are tracked; the most recent live one is activated first. If it has
+    been closed, the command falls back to older ones. If no tracked
+    windows remain, it searches by window class as a final fallback.
+
+2. **Switching from terminal to Sublime**
+
+    Sublime Text also injects the `SUBLIME_TERMINAL_OPENER_WID` environment
+    variable into terminals it opens. You can use this to set up a shell
+    keybinding to switch focus back to Sublime Text. Simply add the following
+    to, e.g., your `~/.bashrc` file:
+
+    ```bash
+    # ~/.bashrc
+    if [ -n "$SUBLIME_TERMINAL_OPENER_WID" ]; then
+        bind -x '"\C-]": "xdotool windowactivate $SUBLIME_TERMINAL_OPENER_WID"'
+    fi
+    ```
+
+    Here `\C-]` refers to `Ctrl+]`. Any terminal opened from Sublime Text
+    will have this keybinding available in bash sessions that source
+    `~/.bashrc`. The keybinding is arbitrary and easy to change (see
+    [here](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html)
+    or [here](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html)).
 
 ## Example configurations
 

--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,9 @@ Here are some example configurations calling different terminals. Note that path
 }
 ```
 
-### xterm on GNU/Linux
+### GNU/Linux
+
+#### xterm
 
 ```json
 {
@@ -137,7 +139,7 @@ Here are some example configurations calling different terminals. Note that path
 }
 ```
 
-### gnome-terminal for CJK users on GNU/Linux
+#### gnome-terminal (CJK users)
 
 We unset LD_PRELOAD, as it may cause problems for Sublime Text with imfix.
 
@@ -147,6 +149,20 @@ We unset LD_PRELOAD, as it may cause problems for Sublime Text with imfix.
   "env": {"LD_PRELOAD": null}
 }
 ```
+
+#### Ghostty, Kitty, WezTerm, Alacritty
+
+Modern terminals that support GPU-accelerated rendering and 24-bit true color:
+
+```json
+{
+  "terminal": "ghostty"
+  // "terminal": "kitty"
+  // "terminal": "wezterm"
+  // "terminal": "alacritty"
+}
+```
+
 ### iTerm on MacOS.
 
 ```json

--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,8 @@ Note that in version 2 of this package, we stopped enabling these bindings by de
 The settings can be viewed and edited by accessing the *Preferences > Package Settings > Terminal > Settings* menu entry. 
 
  - **terminal**
-     - The terminal to execute, will default to the OS default if blank.
-     - Default: `""`
+     - The terminal to execute, will default to the OS default if not set.
+     - Default: `null`
  - **parameters**
      - The parameters to pass to the terminal. These parameters will be used if no [custom parameters](#custom-parameters) are passed.
      - Default: `[]`
@@ -58,7 +58,7 @@ The settings can be viewed and edited by accessing the *Preferences > Package Se
      - Default: `{}`
  - **terminal_class**
      - The WM_CLASS of the terminal, used by "Switch to Terminal" on Linux. If blank, derived from the `terminal` setting. Override this if your terminal's WM_CLASS differs from its executable name. Find yours with: `xdotool getactivewindow getwindowclassname`
-     - Default: `""`
+     - Default: `null`
 
 ## Custom Parameters
 

--- a/readme.md
+++ b/readme.md
@@ -125,11 +125,18 @@ A parameter may also contain the *%CWD%* placeholder, which will be substituted 
 
     ```bash
     # ~/.bashrc
-    bind -x '"\C-]": "hyprctl dispatch focuswindow tag:sublime-opener >/dev/null 2>&1"'
+    sublime_terminal_focus_opener() {
+        hyprctl dispatch focuswindow "tag:$SUBLIME_TERMINAL_OPENER_TAG" \
+            >/dev/null 2>&1
+    }
+
+    if [ -n "$SUBLIME_TERMINAL_OPENER_TAG" ]; then
+        bind -x '"\C-]": sublime_terminal_focus_opener'
+    fi
     ```
 
-    On Hyprland, the plugin tags Sublime's window instead of using an
-    environment variable.
+    On Hyprland, the plugin tags Sublime's opener window and injects
+    `SUBLIME_TERMINAL_OPENER_TAG` into the terminal environment.
 
     Here `\C-]` refers to `Ctrl+]`. The key binding is arbitrary and
     easy to change (see

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,11 @@ Download [Package Control](https://packagecontrol.io/) and use the *Package Cont
   Opens a terminal in the project folder containing the currently opened file.  
 - **Switch to Terminal**
   Switches focus to the most recently opened terminal window.
-  On macOS this uses AppleScript. On Linux this requires
-  [xdotool](https://github.com/jordansissel/xdotool), pre-installed or
-  available via your distribution's package manager:
+  Available on macOS (via AppleScript) and Linux (via
+  [xdotool](https://github.com/jordansissel/xdotool)).
+  Not currently supported on Windows.
+
+  On Linux, xdotool must be installed:
 
   - Debian/Ubuntu/Mint: `sudo apt install xdotool`
   - Arch: `sudo pacman -S xdotool`
@@ -33,7 +35,8 @@ To create keyboard shortcuts, open the *Preferences > Package Settings > Termina
 ```json
 [
   { "keys": ["super+shift+t"], "command": "open_terminal" },
-  { "keys": ["super+shift+alt+t"], "command": "open_terminal_project_folder" }
+  { "keys": ["super+shift+alt+t"], "command": "open_terminal_project_folder" },
+  { "keys": ["super+\\"], "command": "switch_to_terminal" }
 ]
 ```
 
@@ -100,7 +103,7 @@ A parameter may also contain the *%CWD%* placeholder, which will be substituted 
 
     Sublime Text also injects the `SUBLIME_TERMINAL_OPENER_WID` environment
     variable into terminals it opens. You can use this to set up a shell
-    keybinding to switch focus back to Sublime Text. Simply add the following
+    key binding to switch focus back to Sublime Text. Simply add the following
     to, e.g., your `~/.bashrc` file:
 
     ```bash
@@ -111,8 +114,8 @@ A parameter may also contain the *%CWD%* placeholder, which will be substituted 
     ```
 
     Here `\C-]` refers to `Ctrl+]`. Any terminal opened from Sublime Text
-    will have this keybinding available in bash sessions that source
-    `~/.bashrc`. The keybinding is arbitrary and easy to change (see
+    will have this key binding available in bash sessions that source
+    `~/.bashrc`. The key binding is arbitrary and easy to change (see
     [here](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html)
     or [here](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html)).
 

--- a/readme.md
+++ b/readme.md
@@ -14,15 +14,19 @@ Download [Package Control](https://packagecontrol.io/) and use the *Package Cont
   Opens a terminal in the project folder containing the currently opened file.  
 - **Switch to Terminal**
   Switches focus to the most recently opened terminal window.
-  Available on macOS (via AppleScript) and Linux (via
-  [xdotool](https://github.com/jordansissel/xdotool)).
+  Available on macOS (via AppleScript) and Linux
+  ([xdotool](https://github.com/jordansissel/xdotool) on X11,
+  [hyprctl](https://wiki.hyprland.org/) on Hyprland;
+  other Wayland compositors are not currently supported).
   Not currently supported on Windows.
 
-  On Linux, xdotool must be installed:
+  On Linux with X11, xdotool must be installed:
 
   - Debian/Ubuntu/Mint: `sudo apt install xdotool`
   - Arch: `sudo pacman -S xdotool`
   - Fedora: `sudo dnf install xdotool`
+
+  On Hyprland, `hyprctl` is detected automatically (no extra install needed).
 
 
 
@@ -101,10 +105,11 @@ A parameter may also contain the *%CWD%* placeholder, which will be substituted 
 
 2. **Switching from terminal to Sublime**
 
-    Sublime Text also injects the `SUBLIME_TERMINAL_OPENER_WID` environment
-    variable into terminals it opens. You can use this to set up a shell
-    key binding to switch focus back to Sublime Text. Simply add the following
-    to, e.g., your `~/.bashrc` file:
+    To switch focus back from the terminal to Sublime, add a shell key
+    binding to your `~/.bashrc` (the plugin cannot register bindings
+    inside external terminals):
+
+    For X11 (xdotool):
 
     ```bash
     # ~/.bashrc
@@ -113,9 +118,21 @@ A parameter may also contain the *%CWD%* placeholder, which will be substituted 
     fi
     ```
 
-    Here `\C-]` refers to `Ctrl+]`. Any terminal opened from Sublime Text
-    will have this key binding available in bash sessions that source
-    `~/.bashrc`. The key binding is arbitrary and easy to change (see
+    On X11, the plugin injects `SUBLIME_TERMINAL_OPENER_WID` into the
+    terminal's environment with Sublime's window ID.
+
+    For Hyprland (Wayland):
+
+    ```bash
+    # ~/.bashrc
+    bind -x '"\C-]": "hyprctl dispatch focuswindow tag:sublime-opener >/dev/null 2>&1"'
+    ```
+
+    On Hyprland, the plugin tags Sublime's window instead of using an
+    environment variable.
+
+    Here `\C-]` refers to `Ctrl+]`. The key binding is arbitrary and
+    easy to change (see
     [here](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html)
     or [here](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html)).
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,27 @@ A parameter may also contain the *%CWD%* placeholder, which will be substituted 
     [here](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html)
     or [here](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html)).
 
+#### Troubleshooting
+
+Some Hyprland or Wayland terminals may inherit the working directory from an
+existing terminal window instead of using the cwd passed by Sublime. If a new
+terminal opens in a previous shell directory, configure the terminal to accept
+an explicit working directory argument.
+
+For example, Ghostty on Hyprland can be configured as:
+
+```json
+{
+  "terminal": "ghostty",
+  "parameters": [
+    "--gtk-single-instance=false",
+    "--window-inherit-working-directory=false",
+    "--working-directory=%CWD%"
+  ],
+  "terminal_class": "com.mitchellh.ghostty"
+}
+```
+
 ## Example configurations
 
 Here are some example configurations calling different terminals. Note that paths to executables might differ on your machine.


### PR DESCRIPTION
Fix #9 

- extends the "Switch to Terminal" command to work on Linux via   [xdotool](https://github.com/jordansissel/xdotool) (fcb4a82)

- enables bidirectional switching between Sublime Text and the terminal for linux (fcb4a82)

- documents the command for both macOS and Linux (previously undocumented) (3f43a01 and 570491ed)

- adds example configurations for modern GPU-accelerated terminals (8ae532d)


### Testing

Tested with Ghostty, Kitty, Alacritty, WezTerm, and gnome-terminal locally on Linux Mint 21.1 (Cinnamon/X11). Its quite simple so should work whenever xdotool is installed (which can be installed everhwywhere)

regarding the error message, it looks like so if xdotool is not install but a keybinding is nevertheless set:

<img width="451" height="165" alt="image" src="https://github.com/user-attachments/assets/e0479498-3dab-4694-9b37-4c6c6e18143c" />
